### PR TITLE
Add simple interest calculator

### DIFF
--- a/simple_interest.py
+++ b/simple_interest.py
@@ -1,0 +1,5 @@
+P = float(input('Enter the principal amount: '))
+R = float(input('Enter the rate of interest: '))
+T = float(input('Enter the time in years: '))
+SI = (P * R * T) / 100
+print(f'Simple Interest: {SI}')


### PR DESCRIPTION
## Summary
- add a simple interest calculator script that prompts for principal, rate, and time, then outputs the computed simple interest

## Testing
- `pytest` *(fails: ProxyError attempting to reach jsonplaceholder.typicode.com)*

------
https://chatgpt.com/codex/tasks/task_e_689fa5129ab4832aa057aeafe4812a00